### PR TITLE
[ALC-2] add comment explaining contract owner limitations for user operation validation

### DIFF
--- a/src/LightAccount.sol
+++ b/src/LightAccount.sol
@@ -32,6 +32,15 @@ import {CustomSlotInitializable} from "./CustomSlotInitializable.sol";
  * exposing its own `isValidSignature` method. This only works when the owner of
  * LightAccount also support ERC-1271.
  *
+ * ERC-4337's bundler validation rules limit the types of contracts that can be
+ * used as owners to validate user operation signatures. For example, the
+ * contract's `isValidSignature` function may not use any forbidden opcodes
+ * such as `TIMESTAMP` or `NUMBER`, and the contract may not be an ERC-1967
+ * proxy as it accesses a constant implementation slot not associated with
+ * the account, violating storage access rules. This also means that the
+ * owner of a LightAccount may not be another LightAccount if you want to send
+ * user operations through a bundler.
+ *
  * 4. Event `SimpleAccountInitialized` renamed to `LightAccountInitialized`.
  */
 contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, CustomSlotInitializable, IERC1271 {


### PR DESCRIPTION
Addresses:
ALC-2: Bundler may drop UserOps if the owner of LightAccount violates ERC-4337's storage requirement in isValidSignature()