### PR TITLE
fix: address best practices

### DIFF
--- a/test/CustomSlotInitializable.t.sol
+++ b/test/CustomSlotInitializable.t.sol
@@ -40,26 +40,26 @@ contract CustomSlotInitializableTest is Test {
     }
 
     function testCannotReinitialize() public {
-        vm.expectRevert(bytes("Initializable: contract is already initialized"));
+        vm.expectRevert(CustomSlotInitializable.InvalidInitialization.selector);
         v1Proxy.upgradeToAndCall(v1Impl, abi.encodeCall(V1.initialize, ()));
     }
 
     function testCannotUpgradeBackwards() public {
         v1Proxy.upgradeToAndCall(v2Impl, abi.encodeCall(V2.initialize, ()));
         V2 v2Proxy = V2(address(v1Proxy));
-        vm.expectRevert(bytes("Initializable: contract is already initialized"));
+        vm.expectRevert(CustomSlotInitializable.InvalidInitialization.selector);
         v2Proxy.upgradeToAndCall(v1Impl, abi.encodeCall(V1.initialize, ()));
     }
 
     function testDisableInitializers() public {
         v1Proxy.disableInitializers();
-        vm.expectRevert(bytes("Initializable: contract is already initialized"));
+        vm.expectRevert(CustomSlotInitializable.InvalidInitialization.selector);
         v1Proxy.upgradeToAndCall(v2Impl, abi.encodeCall(V2.initialize, ()));
     }
 
     function testCannotCallDisableInitializersInInitializer() public {
         DisablesInitializersWhileInitializing account = new DisablesInitializersWhileInitializing();
-        vm.expectRevert("Initializable: contract is initializing");
+        vm.expectRevert(CustomSlotInitializable.InvalidInitialization.selector);
         account.initialize();
     }
 

--- a/test/LightAccount.t.sol
+++ b/test/LightAccount.t.sol
@@ -82,7 +82,7 @@ contract LightAccountTest is Test {
     }
 
     function testExecuteCannotBeCalledByRandos() public {
-        vm.expectRevert(bytes("account: not Owner or EntryPoint"));
+        vm.expectRevert(abi.encodeWithSelector(LightAccount.NotAuthorized.selector, (address(this))));
         account.execute(address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ()));
     }
 
@@ -110,7 +110,7 @@ contract LightAccountTest is Test {
         dest[1] = address(lightSwitch);
         bytes[] memory func = new bytes[](1);
         func[0] = abi.encodeCall(LightSwitch.turnOn, ());
-        vm.expectRevert(bytes("wrong array lengths"));
+        vm.expectRevert(LightAccount.ArrayLengthMismatch.selector);
         account.executeBatch(dest, func);
     }
 
@@ -136,7 +136,7 @@ contract LightAccountTest is Test {
         value[1] = uint256(1 ether);
         bytes[] memory func = new bytes[](1);
         func[0] = abi.encodeCall(LightSwitch.turnOn, ());
-        vm.expectRevert(bytes("wrong array lengths"));
+        vm.expectRevert(LightAccount.ArrayLengthMismatch.selector);
         account.executeBatch(dest, value, func);
     }
 
@@ -163,7 +163,7 @@ contract LightAccountTest is Test {
 
     function testWithdrawDepositToCannotBeCalledByRandos() public {
         account.addDeposit{value: 10}();
-        vm.expectRevert(bytes("only owner"));
+        vm.expectRevert(abi.encodeWithSelector(LightAccount.NotAuthorized.selector, (address(this))));
         account.withdrawDepositTo(BENEFICIARY, 5);
     }
 
@@ -189,19 +189,19 @@ contract LightAccountTest is Test {
     }
 
     function testRandosCannotTransferOwnership() public {
-        vm.expectRevert(bytes("only owner"));
+        vm.expectRevert(abi.encodeWithSelector(LightAccount.NotAuthorized.selector, (address(this))));
         account.transferOwnership(address(0x100));
     }
 
     function testCannotTransferOwnershipToZero() public {
         vm.prank(eoaAddress);
-        vm.expectRevert(bytes("account: new owner is the zero address"));
+        vm.expectRevert(abi.encodeWithSelector(LightAccount.InvalidOwner.selector, (address(0))));
         account.transferOwnership(address(0));
     }
 
     function testCannotTransferOwnershipToLightContractItself() public {
         vm.prank(eoaAddress);
-        vm.expectRevert(bytes("account: new owner is self"));
+        vm.expectRevert(abi.encodeWithSelector(LightAccount.InvalidOwner.selector, (address(account))));
         account.transferOwnership(address(account));
     }
 
@@ -244,7 +244,7 @@ contract LightAccountTest is Test {
         // Try to upgrade to a normal SimpleAccount with a different entry point.
         IEntryPoint newEntryPoint = IEntryPoint(address(0x2000));
         SimpleAccount newImplementation = new SimpleAccount(newEntryPoint);
-        vm.expectRevert(bytes("only owner"));
+        vm.expectRevert(abi.encodeWithSelector(LightAccount.NotAuthorized.selector, (address(this))));
         account.upgradeToAndCall(address(newImplementation), abi.encodeCall(SimpleAccount.initialize, (address(this))));
     }
 


### PR DESCRIPTION
1. Use custom errors in place of require statements for gas savings.
    - Fixed.
2. Address.isContract() will be removed in the OZ-contracts 5.0 release. Consider replacing it with (address(this).code.length > 0)
    - Fixed.
3. Typo "_getInitialiazableStorage()" ⇒ "_getInitializableStorage()".
    - Fixed.
4. Global state variables, such as CustomSlotInitializable._storagePosition , should not have a leading underscore.
    - Acknowledged. We'll keep this to follow our convention of leading underscores for internal / private variables.
5. For loops can be gas-optimized by cashing the array.length in a memory variable and incrementing the iterator via unchecked {++i;} .
    - Fixed.
6. LightAccount.transferOwnership() can be restricted to external visibility.
    - Fixed.
8. _getInitialiazableStorage() can load directly from a constant and does not need a temporary variable.
    - Acknowledged. Assembly access to immutable variables is not supported, so we're keeping this.