### PR TITLE
chore: update config, validate init code hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Foundry build and cache directories
 out/
 cache/
+.env

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,7 +7,7 @@ out = 'out'
 test = 'test'
 libs = ['lib']
 optimizer = true
-optimizer_runs = 10_000
+optimizer_runs = 10_000_000
 
 [fuzz]
 runs = 5000

--- a/script/Deploy_LightAccountFactory.s.sol
+++ b/script/Deploy_LightAccountFactory.s.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.19;
+
+import "forge-std/Script.sol";
+
+import {IEntryPoint} from "account-abstraction/interfaces/IEntryPoint.sol";
+
+import {LightAccountFactory} from "../src/LightAccountFactory.sol";
+
+// @notice Deploys LightAccountFactory to the address `0x006A000bb900dC0781A5290e210F000000e92200`
+// @dev Note: EntryPoint must be at 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+// @dev To run: `forge script script/Deploy_LightAccountFactory.s.sol:Deploy_LightAccountFactory --broadcast --rpc-url ${RPC_URL} --verify -vvvv`
+contract Deploy_LightAccountFactory is Script {
+    error InitCodeHashMismatch(bytes32 initCodeHash);
+    error DeployedAddressMismatch(address deployed);
+
+    function run() public {
+        uint256 deployerPrivateKey = uint256(vm.envBytes32("DEPLOYER_PRIVATE_KEY"));
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Using entryPoint: 0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789
+        // Correct as of Oct 3 2023, from https://docs.alchemy.com/reference/eth-supportedentrypoints
+        IEntryPoint entryPoint = IEntryPoint(payable(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789));
+
+        // Init code hash check
+        bytes32 initCodeHash = keccak256(
+            abi.encodePacked(type(LightAccountFactory).creationCode, bytes32(uint256(uint160(address(entryPoint)))))
+        );
+
+        if (initCodeHash != 0x3043a72812fec9b9987853a9b869c1a469dc6e04b0f80da3af2ecb8cf8eed209) {
+            revert InitCodeHashMismatch(initCodeHash);
+        }
+
+        console.log("********************************");
+        console.log("******** Deploy Inputs *********");
+        console.log("********************************");
+        console.log("Entrypoint Address is:");
+        console.logAddress(address(entryPoint));
+        console.log("********************************");
+        console.log("******** Deploy ...... *********");
+        console.log("********************************");
+
+        LightAccountFactory factory =
+        new LightAccountFactory{salt: 0x00000000000000000000000000000000000000007845d3459c316000001d6f83}(entryPoint);
+
+        // Deployed address check
+        if (address(factory) != 0x000000893A26168158fbeaDD9335Be5bC96592E2) {
+            revert DeployedAddressMismatch(address(factory));
+        }
+
+        console.log("LightAccountFactory address:");
+        console.logAddress(address(factory));
+
+        console.log("Implementation address:");
+        console.logAddress(address(factory.accountImplementation()));
+        vm.stopBroadcast();
+    }
+}

--- a/test/LightAccount.t.sol
+++ b/test/LightAccount.t.sol
@@ -277,6 +277,18 @@ contract LightAccountTest is Test {
         assertEq(initialized, 1);
     }
 
+    function testValidateInitCodeHash() external {
+        assertEq(
+            keccak256(
+                abi.encodePacked(
+                    type(LightAccountFactory).creationCode,
+                    bytes32(uint256(uint160(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789)))
+                )
+            ),
+            0x3043a72812fec9b9987853a9b869c1a469dc6e04b0f80da3af2ecb8cf8eed209
+        );
+    }
+
     function _useContractOwner() internal {
         vm.prank(eoaAddress);
         account.transferOwnership(address(contractOwner));


### PR DESCRIPTION
## Motivation

Increasing runs reduces gas costs on aa-benchmark (note that increasing from 10,000,000 to maximum which is uint32.max doesn't change it any more)

## Solution

Increased runs to 10,000,000 + added test to validate init code hash