### PR TITLE
fix: generate domain separator per 712 spec

### DIFF
--- a/.gasestimates.md
+++ b/.gasestimates.md
@@ -4,126 +4,147 @@ Generated via `bash utils/inspect.sh`.
 ---
 
 `forge test --gas-report --no-match-path "test/script/**/*"`
+| PRECOMPILES contract |                 |      |        |      |         |
+|----------------------|-----------------|------|--------|------|---------|
+| Deployment Cost      | Deployment Size |      |        |      |         |
+| 0                    | 0               |      |        |      |         |
+| Function Name        | min             | avg  | median | max  | # calls |
+| ecrecover            | 3000            | 3000 | 3000   | 3000 | 5       |
+
+
 | lib/account-abstraction/contracts/core/EntryPoint.sol:EntryPoint contract |                 |        |        |        |         |
 |---------------------------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                                           | Deployment Size |        |        |        |         |
-| 4128022                                                                   | 20516           |        |        |        |         |
+| 4781904                                                                   | 23781           |        |        |        |         |
 | Function Name                                                             | min             | avg    | median | max    | # calls |
-| balanceOf                                                                 | 614             | 1014   | 614    | 2614   | 5       |
-| depositTo                                                                 | 22537           | 23870  | 24537  | 24537  | 3       |
-| getUserOpHash                                                             | 2178            | 2181   | 2178   | 2187   | 3       |
-| handleOps                                                                 | 67556           | 114566 | 128637 | 147506 | 3       |
-| innerHandleOp                                                             | 33718           | 43164  | 43164  | 52611  | 2       |
-| receive                                                                   | 22127           | 22127  | 22127  | 22127  | 3       |
-| withdrawTo                                                                | 36996           | 36996  | 36996  | 36996  | 1       |
+| balanceOf                                                                 | 587             | 987    | 587    | 2587   | 5       |
+| depositTo                                                                 | 22498           | 23831  | 24498  | 24498  | 3       |
+| getUserOpHash                                                             | 2142            | 2144   | 2142   | 2151   | 4       |
+| handleOps                                                                 | 67324           | 119845 | 132443 | 147171 | 4       |
+| innerHandleOp                                                             | 52568           | 52568  | 52568  | 52568  | 1       |
+| receive                                                                   | 22103           | 22103  | 22103  | 22103  | 1       |
+| withdrawTo                                                                | 36957           | 36957  | 36957  | 36957  | 1       |
 
 
 | lib/account-abstraction/contracts/samples/SimpleAccount.sol:SimpleAccount contract |                 |       |        |       |         |
 |------------------------------------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                                                    | Deployment Size |       |        |       |         |
-| 1479733                                                                            | 7684            |       |        |       |         |
+| 1676343                                                                            | 8675            |       |        |       |         |
 | Function Name                                                                      | min             | avg   | median | max   | # calls |
-| entryPoint                                                                         | 407             | 407   | 407    | 407   | 1       |
-| initialize                                                                         | 26217           | 26217 | 26217  | 26217 | 1       |
-| proxiableUUID                                                                      | 387             | 387   | 387    | 387   | 1       |
+| entryPoint                                                                         | 404             | 404   | 404    | 404   | 1       |
+| initialize                                                                         | 26214           | 26214 | 26214  | 26214 | 1       |
+| proxiableUUID                                                                      | 384             | 384   | 384    | 384   | 1       |
 
 
 | lib/openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol:ERC1967Proxy contract |                 |       |        |       |         |
 |-------------------------------------------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                                                           | Deployment Size |       |        |       |         |
-| 120671                                                                                    | 1228            |       |        |       |         |
+| 120773                                                                                    | 1228            |       |        |       |         |
 | Function Name                                                                             | min             | avg   | median | max   | # calls |
-| addDeposit                                                                                | 30212           | 36212 | 39212  | 39212 | 3       |
-| disableInitializers                                                                       | 11105           | 11105 | 11105  | 11105 | 1       |
-| entryPoint                                                                                | 723             | 2984  | 2984   | 5245  | 2       |
-| execute                                                                                   | 7455            | 16650 | 8658   | 32984 | 5       |
-| executeBatch                                                                              | 7794            | 20627 | 20627  | 33460 | 2       |
-| getDeposit                                                                                | 1825            | 4825  | 1825   | 10825 | 3       |
+| addDeposit                                                                                | 30214           | 36214 | 39214  | 39214 | 3       |
+| disableInitializers                                                                       | 11109           | 11109 | 11109  | 11109 | 1       |
+| entryPoint                                                                                | 720             | 3014  | 3014   | 5308  | 2       |
+| execute                                                                                   | 7811            | 23164 | 26434  | 39767 | 5       |
+| executeBatch(address[],bytes[])                                                           | 7732            | 20570 | 20570  | 33409 | 2       |
+| executeBatch(address[],uint256[],bytes[])                                                 | 8039            | 24265 | 24265  | 40492 | 2       |
+| getDeposit                                                                                | 1861            | 4861  | 1861   | 10861 | 3       |
 | getInitializedVersion                                                                     | 677             | 677   | 677    | 677   | 1       |
-| isValidSignature                                                                          | 11229           | 12909 | 12909  | 14589 | 2       |
-| owner                                                                                     | 826             | 826   | 826    | 826   | 2       |
-| transferOwnership                                                                         | 5863            | 8281  | 7744   | 12342 | 5       |
-| upgradeToAndCall                                                                          | 4786            | 17805 | 13316  | 42122 | 7       |
-| validateUserOp                                                                            | 40706           | 41828 | 40712  | 44066 | 3       |
-| withdrawDepositTo                                                                         | 2978            | 21626 | 21626  | 40275 | 2       |
+| getMessageHash                                                                            | 1665            | 4665  | 6165   | 6165  | 3       |
+| isValidSignature                                                                          | 3990            | 7475  | 7537   | 10898 | 3       |
+| owner                                                                                     | 867             | 867   | 867    | 867   | 1       |
+| transferOwnership                                                                         | 7725            | 9803  | 7948   | 12446 | 7       |
+| upgradeToAndCall                                                                          | 4572            | 17748 | 13221  | 42178 | 7       |
+| validateUserOp                                                                            | 32648           | 39525 | 40699  | 44056 | 4       |
+| withdrawDepositTo                                                                         | 2967            | 21632 | 21632  | 40298 | 2       |
 
 
 | src/LightAccount.sol:LightAccount contract |                 |       |        |       |         |
 |--------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                            | Deployment Size |       |        |       |         |
-| 1661569                                    | 8640            |       |        |       |         |
+| 1947528                                    | 10021           |       |        |       |         |
 | Function Name                              | min             | avg   | median | max   | # calls |
-| addDeposit                                 | 29899           | 32899 | 34399  | 34399 | 3       |
-| entryPoint                                 | 429             | 429   | 429    | 429   | 1       |
-| execute                                    | 2950            | 13606 | 7112   | 28147 | 5       |
-| executeBatch                               | 2920            | 15762 | 15762  | 28605 | 2       |
-| getDeposit                                 | 1509            | 3009  | 1509   | 6009  | 3       |
-| initialize                                 | 49609           | 49609 | 49609  | 49609 | 25      |
-| isValidSignature                           | 6383            | 8063  | 8063   | 9743  | 2       |
-| owner                                      | 510             | 510   | 510    | 510   | 2       |
-| transferOwnership                          | 2878            | 4355  | 2912   | 7526  | 5       |
-| upgradeToAndCall                           | 3295            | 20290 | 20290  | 37285 | 2       |
-| validateUserOp                             | 35733           | 36853 | 35733  | 39093 | 3       |
-| withdrawDepositTo                          | 2643            | 21299 | 21299  | 39956 | 2       |
+| addDeposit                                 | 29901           | 32901 | 34401  | 34401 | 3       |
+| entryPoint                                 | 492             | 492   | 492    | 492   | 1       |
+| execute                                    | 2967            | 19223 | 26097  | 34930 | 5       |
+| executeBatch(address[],bytes[])            | 2867            | 15710 | 15710  | 28554 | 2       |
+| executeBatch(address[],uint256[],bytes[])  | 3156            | 19387 | 19387  | 35619 | 2       |
+| getDeposit                                 | 1545            | 3045  | 1545   | 6045  | 3       |
+| getMessageHash                             | 1337            | 1337  | 1337   | 1337  | 3       |
+| initialize                                 | 23308           | 48934 | 49711  | 49711 | 34      |
+| isValidSignature                           | 3650            | 7131  | 7191   | 10552 | 3       |
+| owner                                      | 551             | 551   | 551    | 551   | 1       |
+| transferOwnership                          | 2902            | 4983  | 3125   | 7630  | 7       |
+| upgradeToAndCall                           | 3293            | 20317 | 20317  | 37341 | 2       |
+| validateUserOp                             | 32181           | 35677 | 35723  | 39083 | 4       |
+| withdrawDepositTo                          | 2641            | 21310 | 21310  | 39979 | 2       |
 
 
 | src/LightAccountFactory.sol:LightAccountFactory contract |                 |        |        |        |         |
 |----------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                          | Deployment Size |        |        |        |         |
-| 2154580                                                  | 11142           |        |        |        |         |
+| 2440855                                                  | 12523           |        |        |        |         |
 | Function Name                                            | min             | avg    | median | max    | # calls |
-| createAccount                                            | 4821            | 155115 | 161027 | 163527 | 26      |
+| createAccount                                            | 4821            | 154660 | 161129 | 163629 | 35      |
 | getAddress                                               | 4672            | 4672   | 4672   | 4672   | 1       |
 
 
 | test/CustomSlotInitializable.t.sol:DisablesInitializersWhileInitializing contract |                 |       |        |       |         |
 |-----------------------------------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                                                   | Deployment Size |       |        |       |         |
-| 156238                                                                            | 852             |       |        |       |         |
+| 125208                                                                            | 697             |       |        |       |         |
 | Function Name                                                                     | min             | avg   | median | max   | # calls |
-| initialize                                                                        | 22755           | 22755 | 22755  | 22755 | 1       |
+| initialize                                                                        | 22720           | 22720 | 22720  | 22720 | 1       |
 
 
 | test/CustomSlotInitializable.t.sol:IsInitializingChecker contract |                 |       |        |       |         |
 |-------------------------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                                   | Deployment Size |       |        |       |         |
-| 154653                                                            | 851             |       |        |       |         |
+| 146241                                                            | 809             |       |        |       |         |
 | Function Name                                                     | min             | avg   | median | max   | # calls |
-| initialize                                                        | 46069           | 46069 | 46069  | 46069 | 1       |
-| isInitializing                                                    | 303             | 303   | 303    | 303   | 1       |
-| wasInitializing                                                   | 267             | 267   | 267    | 267   | 1       |
+| initialize                                                        | 46108           | 46108 | 46108  | 46108 | 1       |
+| isInitializing                                                    | 306             | 306   | 306    | 306   | 1       |
+| wasInitializing                                                   | 271             | 271   | 271    | 271   | 1       |
 
 
 | test/CustomSlotInitializable.t.sol:V1 contract |                 |       |        |       |         |
 |------------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                                | Deployment Size |       |        |       |         |
-| 762520                                         | 3920            |       |        |       |         |
+| 768527                                         | 3951            |       |        |       |         |
 | Function Name                                  | min             | avg   | median | max   | # calls |
-| disableInitializers                            | 6292            | 6292  | 6292   | 6292  | 1       |
-| getInitializedVersion                          | 391             | 391   | 391    | 391   | 1       |
-| initialize                                     | 684             | 19455 | 23898  | 23898 | 10      |
-| proxiableUUID                                  | 273             | 273   | 273    | 273   | 2       |
-| upgradeToAndCall                               | 8469            | 13681 | 14454  | 17349 | 4       |
+| disableInitializers                            | 6296            | 6296  | 6296   | 6296  | 1       |
+| getInitializedVersion                          | 388             | 388   | 388    | 388   | 1       |
+| initialize                                     | 509             | 19454 | 23926  | 23926 | 10      |
+| proxiableUUID                                  | 270             | 270   | 270    | 270   | 2       |
+| upgradeToAndCall                               | 8386            | 13630 | 14397  | 17343 | 4       |
 
 
 | test/CustomSlotInitializable.t.sol:V2 contract |                 |      |        |      |         |
 |------------------------------------------------|-----------------|------|--------|------|---------|
 | Deployment Cost                                | Deployment Size |      |        |      |         |
-| 703047                                         | 3616            |      |        |      |         |
+| 687034                                         | 3536            |      |        |      |         |
 | Function Name                                  | min             | avg  | median | max  | # calls |
 | getInitializedVersion                          | 361             | 361  | 361    | 361  | 1       |
-| initialize                                     | 504             | 4410 | 6363   | 6363 | 3       |
+| initialize                                     | 423             | 4381 | 6360   | 6360 | 3       |
 | proxiableUUID                                  | 243             | 243  | 243    | 243  | 3       |
-| upgradeToAndCall                               | 3552            | 3552 | 3552   | 3552 | 1       |
+| upgradeToAndCall                               | 3390            | 3390 | 3390   | 3390 | 1       |
 
 
 | test/LightAccount.t.sol:LightSwitch contract |                 |       |        |       |         |
 |----------------------------------------------|-----------------|-------|--------|-------|---------|
 | Deployment Cost                              | Deployment Size |       |        |       |         |
-| 52111                                        | 288             |       |        |       |         |
+| 51305                                        | 284             |       |        |       |         |
 | Function Name                                | min             | avg   | median | max   | # calls |
-| on                                           | 267             | 267   | 267    | 267   | 3       |
-| turnOn                                       | 22274           | 22274 | 22274  | 22274 | 3       |
+| on                                           | 267             | 267   | 267    | 267   | 5       |
+| turnOn                                       | 22259           | 22259 | 22259  | 22259 | 5       |
+
+
+| test/LightAccount.t.sol:Owner contract |                 |     |        |     |         |
+|----------------------------------------|-----------------|-----|--------|-----|---------|
+| Deployment Cost                        | Deployment Size |     |        |     |         |
+| 159608                                 | 825             |     |        |     |         |
+| Function Name                          | min             | avg | median | max | # calls |
+| isValidSignature                       | 767             | 767 | 767    | 767 | 2       |
+| sign                                   | 623             | 623 | 623    | 623 | 2       |
 
 
 | test/LightAccount.t.sol:Reverter contract |                 |     |        |     |         |
@@ -135,7 +156,8 @@ Generated via `bash utils/inspect.sh`.
 
 
 
-Ran 3 test suites: 31 tests passed, 0 failed, 0 skipped (31 total tests)
+ 
+Ran 3 test suites: 39 tests passed, 0 failed, 0 skipped (39 total tests)
 `forge inspect src/CustomSlotInitializable.sol:CustomSlotInitializable gasestimates`
 ```json
 null
@@ -145,27 +167,31 @@ null
 ```json
 {
   "creation": {
-    "codeDepositCost": "1636200",
+    "codeDepositCost": "1921800",
     "executionCost": "infinite",
     "totalCost": "infinite"
   },
   "external": {
     "addDeposit()": "infinite",
+    "domainSeparator()": "912",
+    "encodeMessageData(bytes)": "infinite",
     "entryPoint()": "infinite",
     "execute(address,uint256,bytes)": "infinite",
     "executeBatch(address[],bytes[])": "infinite",
+    "executeBatch(address[],uint256[],bytes[])": "infinite",
     "getDeposit()": "infinite",
+    "getMessageHash(bytes)": "infinite",
     "getNonce()": "infinite",
     "initialize(address)": "infinite",
     "isValidSignature(bytes32,bytes)": "infinite",
     "onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)": "infinite",
     "onERC1155Received(address,address,uint256,uint256,bytes)": "infinite",
     "onERC721Received(address,address,uint256,bytes)": "infinite",
-    "owner()": "2510",
+    "owner()": "2551",
     "proxiableUUID()": "infinite",
-    "supportsInterface(bytes4)": "332",
+    "supportsInterface(bytes4)": "329",
     "tokensReceived(address,address,address,uint256,bytes,bytes)": "infinite",
-    "transferOwnership(address)": "30747",
+    "transferOwnership(address)": "30830",
     "upgradeTo(address)": "infinite",
     "upgradeToAndCall(address,bytes)": "infinite",
     "validateUserOp((address,uint256,bytes,bytes,uint256,uint256,uint256,uint256,uint256,bytes,bytes),bytes32,uint256)": "infinite",
@@ -178,7 +204,7 @@ null
     "_initialize(address)": "infinite",
     "_onlyOwner()": "infinite",
     "_requireFromEntryPointOrOwner()": "infinite",
-    "_transferOwnership(address)": "27881",
+    "_transferOwnership(address)": "infinite",
     "_validateSignature(struct UserOperation calldata,bytes32)": "infinite"
   }
 }

--- a/script/Deploy_LightAccountFactory.s.sol
+++ b/script/Deploy_LightAccountFactory.s.sol
@@ -39,8 +39,9 @@ contract Deploy_LightAccountFactory is Script {
         console.log("******** Deploy ...... *********");
         console.log("********************************");
 
-        LightAccountFactory factory =
-        new LightAccountFactory{salt: 0x4e59b44847b379578588920ca78fbf26c0b4956c3406f3bdc271500000c2f72f}(entryPoint);
+        LightAccountFactory factory = new LightAccountFactory{
+            salt: 0x4e59b44847b379578588920ca78fbf26c0b4956c3406f3bdc271500000c2f72f
+        }(entryPoint);
 
         // Deployed address check
         if (address(factory) != 0x00000055C0b4fA41dde26A74435ff03692292FBD) {

--- a/script/Deploy_LightAccountFactory.s.sol
+++ b/script/Deploy_LightAccountFactory.s.sol
@@ -26,7 +26,7 @@ contract Deploy_LightAccountFactory is Script {
             abi.encodePacked(type(LightAccountFactory).creationCode, bytes32(uint256(uint160(address(entryPoint)))))
         );
 
-        if (initCodeHash != 0x2ad62a8bb3850247ef0c4f04e30b584e6eee7caa0e063745e90956653b90eb84) {
+        if (initCodeHash != 0xd77df77274118ffc7c7b2edced505093b1f8695e3b5ced2b2fd2a5b27e4e2b78) {
             revert InitCodeHashMismatch(initCodeHash);
         }
 

--- a/src/LightAccount.sol
+++ b/src/LightAccount.sol
@@ -58,13 +58,11 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
     // bytes4(keccak256("isValidSignature(bytes32,bytes)"))
     bytes4 internal constant _1271_MAGIC_VALUE = 0x1626ba7e;
     IEntryPoint private immutable _ENTRY_POINT;
-    // keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
     bytes32 private constant _DOMAIN_SEPARATOR_TYPEHASH =
-        0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
-    // keccak256("LightAccountMessage(bytes message)");
-    bytes32 private constant _LA_MSG_TYPEHASH = 0x5e3baca2936049843f06038876a12f03627b5edc98025751ecf2ac7562640199;
-    bytes32 private constant _NAME_HASH = keccak256(bytes("LightAccount"));
-    bytes32 private constant _VERSION_HASH = keccak256(bytes("1"));
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 private constant _LA_MSG_TYPEHASH = keccak256("LightAccountMessage(bytes message)");
+    bytes32 private constant _NAME_HASH = keccak256("LightAccount");
+    bytes32 private constant _VERSION_HASH = keccak256("1");
 
     struct LightAccountStorage {
         address owner;
@@ -276,8 +274,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
      * @inheritdoc IERC1271
      */
     function isValidSignature(bytes32 digest, bytes memory signature) public view override returns (bytes4) {
-        bytes memory messageData = encodeMessageData(abi.encode(digest));
-        bytes32 messageHash = keccak256(messageData);
+        bytes32 messageHash = getMessageHash(abi.encode(digest));
         if (SignatureChecker.isValidSignatureNow(owner(), messageHash, signature)) {
             return _1271_MAGIC_VALUE;
         }

--- a/src/LightAccount.sol
+++ b/src/LightAccount.sol
@@ -63,6 +63,8 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
         0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
     // keccak256("LightAccountMessage(bytes message)");
     bytes32 private constant LA_MSG_TYPEHASH = 0x5e3baca2936049843f06038876a12f03627b5edc98025751ecf2ac7562640199;
+    bytes32 private constant _NAME_HASH = keccak256(bytes("LightAccount"));
+    bytes32 private constant _VERSION_HASH = keccak256(bytes("1"));
 
     struct LightAccountStorage {
         address owner;
@@ -237,8 +239,8 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
         return keccak256(
             abi.encode(
                 DOMAIN_SEPARATOR_TYPEHASH,
-                abi.encode("LightAccount"), // name
-                abi.encode("1"), // version
+                _NAME_HASH, // name
+                _VERSION_HASH, // version
                 block.chainid, // chainId
                 address(this) // verifying contract
             )

--- a/src/LightAccount.sol
+++ b/src/LightAccount.sol
@@ -57,12 +57,12 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
         0x33e4b41198cc5b8053630ed667ea7c0c4c873f7fc8d9a478b5d7259cec0a4a00;
     // bytes4(keccak256("isValidSignature(bytes32,bytes)"))
     bytes4 internal constant _1271_MAGIC_VALUE = 0x1626ba7e;
-    IEntryPoint private immutable _entryPoint;
+    IEntryPoint private immutable _ENTRY_POINT;
     // keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
-    bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH =
+    bytes32 private constant _DOMAIN_SEPARATOR_TYPEHASH =
         0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f;
     // keccak256("LightAccountMessage(bytes message)");
-    bytes32 private constant LA_MSG_TYPEHASH = 0x5e3baca2936049843f06038876a12f03627b5edc98025751ecf2ac7562640199;
+    bytes32 private constant _LA_MSG_TYPEHASH = 0x5e3baca2936049843f06038876a12f03627b5edc98025751ecf2ac7562640199;
     bytes32 private constant _NAME_HASH = keccak256(bytes("LightAccount"));
     bytes32 private constant _VERSION_HASH = keccak256(bytes("1"));
 
@@ -107,7 +107,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
     }
 
     constructor(IEntryPoint anEntryPoint) CustomSlotInitializable(_INITIALIZABLE_STORAGE_POSITION) {
-        _entryPoint = anEntryPoint;
+        _ENTRY_POINT = anEntryPoint;
         _disableInitializers();
     }
 
@@ -185,7 +185,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
     /**
      * @notice Called once as part of initialization, either during initial deployment or when first upgrading to
      * this contract.
-     * @dev The _entryPoint member is immutable, to reduce gas consumption.  To upgrade EntryPoint,
+     * @dev The _ENTRY_POINT member is immutable, to reduce gas consumption.  To upgrade EntryPoint,
      * a new implementation of LightAccount must be deployed with the new EntryPoint address, then upgrading
      * the implementation by calling `upgradeTo()`
      * @param anOwner The initial owner of the account
@@ -212,7 +212,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
 
     /// @inheritdoc BaseAccount
     function entryPoint() public view virtual override returns (IEntryPoint) {
-        return _entryPoint;
+        return _ENTRY_POINT;
     }
 
     /**
@@ -238,7 +238,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
     function domainSeparator() public view returns (bytes32) {
         return keccak256(
             abi.encode(
-                DOMAIN_SEPARATOR_TYPEHASH,
+                _DOMAIN_SEPARATOR_TYPEHASH,
                 _NAME_HASH, // name
                 _VERSION_HASH, // version
                 block.chainid, // chainId
@@ -253,7 +253,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
      * @return Encoded message.
      */
     function encodeMessageData(bytes memory message) public view returns (bytes memory) {
-        bytes32 messageHash = keccak256(abi.encode(LA_MSG_TYPEHASH, keccak256(message)));
+        bytes32 messageHash = keccak256(abi.encode(_LA_MSG_TYPEHASH, keccak256(message)));
         return abi.encodePacked("\x19\x01", domainSeparator(), messageHash);
     }
 
@@ -289,7 +289,7 @@ contract LightAccount is BaseAccount, TokenCallbackHandler, UUPSUpgradeable, Cus
             revert InvalidOwner(address(0));
         }
         _getStorage().owner = anOwner;
-        emit LightAccountInitialized(_entryPoint, anOwner);
+        emit LightAccountInitialized(_ENTRY_POINT, anOwner);
         emit OwnershipTransferred(address(0), anOwner);
     }
 

--- a/src/LightAccountFactory.sol
+++ b/src/LightAccountFactory.sol
@@ -38,9 +38,8 @@ contract LightAccountFactory {
         }
         ret = LightAccount(
             payable(
-                new ERC1967Proxy{salt : bytes32(salt)}(
-                    address(accountImplementation),
-                    abi.encodeCall(LightAccount.initialize, (owner))
+                new ERC1967Proxy{salt: bytes32(salt)}(
+                    address(accountImplementation), abi.encodeCall(LightAccount.initialize, (owner))
                 )
             )
         );

--- a/test/LightAccount.t.sol
+++ b/test/LightAccount.t.sol
@@ -285,7 +285,7 @@ contract LightAccountTest is Test {
                     bytes32(uint256(uint160(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789)))
                 )
             ),
-            0x2ad62a8bb3850247ef0c4f04e30b584e6eee7caa0e063745e90956653b90eb84
+            0x440aa2011f50b8d0732da6d2b1ea32ce9596c74e8d3c974fd89a6f9b80bf083b
         );
     }
 

--- a/test/LightAccount.t.sol
+++ b/test/LightAccount.t.sol
@@ -285,7 +285,7 @@ contract LightAccountTest is Test {
                     bytes32(uint256(uint160(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789)))
                 )
             ),
-            0x440aa2011f50b8d0732da6d2b1ea32ce9596c74e8d3c974fd89a6f9b80bf083b
+            0x72db05fba86adbc64040d8949a885cd2a59aa1604d3c84bec19870bd9a7db0d5
         );
     }
 

--- a/test/LightAccount.t.sol
+++ b/test/LightAccount.t.sol
@@ -285,7 +285,7 @@ contract LightAccountTest is Test {
                     bytes32(uint256(uint160(0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789)))
                 )
             ),
-            0x72db05fba86adbc64040d8949a885cd2a59aa1604d3c84bec19870bd9a7db0d5
+            0xd77df77274118ffc7c7b2edced505093b1f8695e3b5ced2b2fd2a5b27e4e2b78
         );
     }
 


### PR DESCRIPTION
<!--
Borrowed from foundry.

Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

## Motivation
I was testing adding the correct 1271 signature verification in aa-sdk and couldn't generate matching signatures. After diving into it a little bit, the reason was the viem was generating the `domainSeparator` part of the 712 hash differently than LightAccount was. This is because `LightAccount` used `abi.encode` for the name and version fields, but it should actually be the keccak hash result of those fields.

Domain Separator Spec: https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator
Defintion of `encodeData` which calls out `keccak256(bytes(string))`: https://eips.ethereum.org/EIPS/eip-712#definition-of-encodedata

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

If your PR solves a particular issue, tag that issue.
-->

## Solution
Update the generation of the domainSeparator to match what client do naturally. This is the same thing that MSCA does as well.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->