### PR TITLE
feat(v2): Add signature enum to user operation signature validation

### DIFF
--- a/src/MultiOwnerLightAccount.sol
+++ b/src/MultiOwnerLightAccount.sol
@@ -39,8 +39,8 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
     enum SignatureTypes {
         EOA, // 0
         CONTRACT, // 1
-        CONTRACT_WITH_ADDR, // 2
-        empty_1, // skip 3 to align bitmap
+        empty_1, // skip 2 to align bitmap
+        CONTRACT_WITH_ADDR, // 3
         TRANSPARENT_EOA, // 4
         TRANSPARENT_CONTRACT, // 5
         empty_2, // skip 6 to align bitmap

--- a/src/MultiOwnerLightAccount.sol
+++ b/src/MultiOwnerLightAccount.sol
@@ -6,6 +6,7 @@ import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/Messa
 import {SignatureChecker} from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
 import {IEntryPoint} from "account-abstraction/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "account-abstraction/interfaces/PackedUserOperation.sol";
+import {SIG_VALIDATION_FAILED, SIG_VALIDATION_SUCCESS} from "account-abstraction/core/Helpers.sol";
 import {CastLib} from "modular-account/helpers/CastLib.sol";
 import {SetValue} from "modular-account/libraries/Constants.sol";
 import {LinkedListSet, LinkedListSetLib} from "modular-account/libraries/LinkedListSetLib.sol";
@@ -232,9 +233,7 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
     /// @return validationData The validation data value. 0 if success is true, 1 (SIG_VALIDATION_FAILED) if
     /// success is false.
     function _successToValidationData(bool success) internal pure returns (uint256 validationData) {
-        assembly ("memory-safe") {
-            validationData := iszero(success)
-        }
+        return success ? SIG_VALIDATION_SUCCESS : SIG_VALIDATION_FAILED;
     }
 
     /// @dev The signature is valid if it is signed by the owner's private key (if the owner is an EOA) or if it is a

--- a/test/MultiOwnerLightAccount.t.sol
+++ b/test/MultiOwnerLightAccount.t.sol
@@ -145,7 +145,10 @@ contract MultiOwnerLightAccountTest is Test {
     }
 
     function testFuzz_rejectsUserOpsWithInvalidSignatureType(uint8 signatureType) public {
-        signatureType = uint8(bound(signatureType, 3, type(uint8).max));
+        // Valid values are 0,1,3
+        if (signatureType != 2) {
+            signatureType = uint8(bound(signatureType, 4, type(uint8).max));
+        }
 
         PackedUserOperation memory op = _getUnsignedOp(
             abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
@@ -576,7 +579,7 @@ contract MultiOwnerLightAccountTest is Test {
                     bytes32(uint256(uint160(0x0000000071727De22E5E9d8BAf0edAc6f37da032)))
                 )
             ),
-            0x3b81b3fa5e00c31f57c12db971bb4fbf4d1eee382ae26b211b2165efbbe07437
+            0x0a14a7d2e0fb6858a618de8e4a7cf52bd1cb8dad3f4adbf243078a4db5f13c92
         );
     }
 

--- a/test/MultiOwnerLightAccount.t.sol
+++ b/test/MultiOwnerLightAccount.t.sol
@@ -72,12 +72,30 @@ contract MultiOwnerLightAccountTest is Test {
         assertTrue(lightSwitch.on());
     }
 
-    function testExecutedCanBeCalledByEntryPointWithContractOwner() public {
+    function testExecuteCanBeCalledByEntryPointWithContractOwnerUnspecified() public {
         _useContractOwner();
         PackedUserOperation memory op = _getUnsignedOp(
             abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
         );
-        op.signature = contractOwner.sign(entryPoint.getUserOpHash(op));
+        op.signature = abi.encodePacked(
+            MultiOwnerLightAccount.SignatureTypes.CONTRACT, contractOwner.sign(entryPoint.getUserOpHash(op))
+        );
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = op;
+        entryPoint.handleOps(ops, BENEFICIARY);
+        assertTrue(lightSwitch.on());
+    }
+
+    function testExecuteCanBeCalledByEntryPointWithContractOwnerSpecified() public {
+        _useContractOwner();
+        PackedUserOperation memory op = _getUnsignedOp(
+            abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
+        );
+        op.signature = abi.encodePacked(
+            MultiOwnerLightAccount.SignatureTypes.CONTRACT_WITH_ADDR,
+            contractOwner,
+            contractOwner.sign(entryPoint.getUserOpHash(op))
+        );
         PackedUserOperation[] memory ops = new PackedUserOperation[](1);
         ops[0] = op;
         entryPoint.handleOps(ops, BENEFICIARY);
@@ -92,6 +110,57 @@ contract MultiOwnerLightAccountTest is Test {
         PackedUserOperation[] memory ops = new PackedUserOperation[](1);
         ops[0] = op;
         vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));
+        entryPoint.handleOps(ops, BENEFICIARY);
+    }
+
+    function testRejectsUserOpWithInvalidContractOwnerSpecified() public {
+        PackedUserOperation memory op = _getUnsignedOp(
+            abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
+        );
+        op.signature = abi.encodePacked(
+            MultiOwnerLightAccount.SignatureTypes.CONTRACT_WITH_ADDR,
+            contractOwner,
+            contractOwner.sign(entryPoint.getUserOpHash(op))
+        );
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = op;
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));
+        entryPoint.handleOps(ops, BENEFICIARY);
+        assertFalse(lightSwitch.on());
+    }
+
+    function testRejectsUserOpWithPartialContractOwnerSpecified() public {
+        _useContractOwner();
+        PackedUserOperation memory op = _getUnsignedOp(
+            abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
+        );
+        op.signature = abi.encodePacked(
+            MultiOwnerLightAccount.SignatureTypes.CONTRACT_WITH_ADDR, bytes10(bytes20(address(contractOwner)))
+        );
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = op;
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOpWithRevert.selector, 0, "AA23 reverted", bytes("")));
+        entryPoint.handleOps(ops, BENEFICIARY);
+        assertFalse(lightSwitch.on());
+    }
+
+    function testFuzz_rejectsUserOpsWithInvalidSignatureType(uint8 signatureType) public {
+        signatureType = uint8(bound(signatureType, 3, type(uint8).max));
+
+        PackedUserOperation memory op = _getUnsignedOp(
+            abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
+        );
+        op.signature = abi.encodePacked(signatureType);
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = op;
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEntryPoint.FailedOpWithRevert.selector,
+                0,
+                "AA23 reverted",
+                abi.encodePacked(MultiOwnerLightAccount.InvalidSignatureType.selector)
+            )
+        );
         entryPoint.handleOps(ops, BENEFICIARY);
     }
 
@@ -323,6 +392,14 @@ contract MultiOwnerLightAccountTest is Test {
         assertEq(owners[0], eoaAddress);
     }
 
+    function testRemoveNonexistantOwner() public {
+        address[] memory ownersToRemove = new address[](1);
+        ownersToRemove[0] = address(0x100);
+        vm.prank(eoaAddress);
+        vm.expectRevert(abi.encodeWithSelector(MultiOwnerLightAccount.OwnerDoesNotExist.selector, (address(0x100))));
+        account.updateOwners(new address[](0), ownersToRemove);
+    }
+
     function testEntryPointGetter() public {
         assertEq(address(account.entryPoint()), address(entryPoint));
     }
@@ -499,7 +576,7 @@ contract MultiOwnerLightAccountTest is Test {
                     bytes32(uint256(uint160(0x0000000071727De22E5E9d8BAf0edAc6f37da032)))
                 )
             ),
-            0x3765ef442bfa3b5ef7a30073b39949186919dd2344bb5aa0736a0e0be66ebfe1
+            0xc673ee55a4508417eef16886472aeca3661be5e66bf59521dee374cf0021fa13
         );
     }
 
@@ -536,7 +613,10 @@ contract MultiOwnerLightAccountTest is Test {
         returns (PackedUserOperation memory)
     {
         PackedUserOperation memory op = _getUnsignedOp(callData);
-        op.signature = _sign(privateKey, entryPoint.getUserOpHash(op).toEthSignedMessageHash());
+        op.signature = abi.encodePacked(
+            MultiOwnerLightAccount.SignatureTypes.EOA,
+            _sign(privateKey, entryPoint.getUserOpHash(op).toEthSignedMessageHash())
+        );
         return op;
     }
 

--- a/test/MultiOwnerLightAccount.t.sol
+++ b/test/MultiOwnerLightAccount.t.sol
@@ -576,7 +576,7 @@ contract MultiOwnerLightAccountTest is Test {
                     bytes32(uint256(uint160(0x0000000071727De22E5E9d8BAf0edAc6f37da032)))
                 )
             ),
-            0xc673ee55a4508417eef16886472aeca3661be5e66bf59521dee374cf0021fa13
+            0x3b81b3fa5e00c31f57c12db971bb4fbf4d1eee382ae26b211b2165efbbe07437
         );
     }
 


### PR DESCRIPTION
## Motivation

- When we validate owner signatures for both user op validation and 1271 signature validation, if the owner is a contract account and there is more than one owner, then the signature verification must loop over all the owners and attempt calling `isValidSignature`. The problem this causes is gas inefficiency and a potential DOS attack a contract owner can perform, where it wastes all gas available in the call to prevent future signature checking.
- When the looping happens during user op validation, the owner addresses will all be warmed by the dummy signature, despite not being warmed when ECDSA verification succeeds. This leads to incorrect gas estimation when the execution step of the user operation interacts with an owner EOA, due to the account being warmed during estimation but not execution.

## Solution

Two pieces of information may be useful - which owner the signature is for, and whether or not the owner is a contract or an EOA. However, the looping behavior might actually be useful for calldata-constrained networks like Optimism, Base, Arbitrum, etc.

So, the proposed solution is to define a 1-byte enum in the front of the signature to allow selecting between the different signing mechanisms .

- Case `0`: EOA signature
    - Signature format: `1 byte enum || 65-byte EOA signature`
- Case `1`: Contract signature, no address
    - Signature format: `1 byte enum || arbitrary-length contract signature`
- Case `2`: Contract signature with address
    - Signature format: `1 byte enum || 20-byte contract address || arbitrary-length contract signature`

This PR only handles the user operation validation checks. A stacked PR will handle the signature verification for the 1271 case. Enum values for the 1271 case have already been included here.