### PR TITLE
fix: [ALC-LA2-2] revert on malformed signature

### DIFF
--- a/test/CustomSlotInitializable.t.sol
+++ b/test/CustomSlotInitializable.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";

--- a/test/LightAccountFactory.t.sol
+++ b/test/LightAccountFactory.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";

--- a/test/MultiOwnerLightAccountFactory.t.sol
+++ b/test/MultiOwnerLightAccountFactory.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.23;
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
Revert instead of returning `SIG_VALIDATION_FAILED` for malformed signatures. Note that this also impacts the ERC-1271 `isValidSignature` flow to revert when the trimmed signature is malformed. This is not prohibited by ERC-1271, so this is fine.

