### PR TITLE
fix: [ALC-LA2-3] remove SignatureType.CONTRACT case from MultiOwnerLightAccount

### DIFF
--- a/src/MultiOwnerLightAccount.sol
+++ b/src/MultiOwnerLightAccount.sol
@@ -130,6 +130,7 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
     /// @dev Implement template method of BaseAccount.
     /// Uses a modified version of `SignatureChecker.isValidSignatureNow` in which the digest is wrapped with an
     /// "Ethereum Signed Message" envelope for the EOA-owner case but not in the ERC-1271 contract-owner case.
+    /// The SignatureType.CONTRACT case is excluded here to prevent potential gas griefing attacks.
     function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
         internal
         virtual
@@ -145,10 +146,6 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
             bytes32 signedHash = userOpHash.toEthSignedMessageHash();
             bytes memory signature = userOp.signature[1:];
             return _successToValidationData(_isValidEOAOwnerSignature(signedHash, signature));
-        } else if (signatureType == uint8(SignatureType.CONTRACT)) {
-            // Contract signature without address
-            bytes memory signature = userOp.signature[1:];
-            return _successToValidationData(_isValidContractOwnerSignatureNowLoop(userOpHash, signature));
         } else if (signatureType == uint8(SignatureType.CONTRACT_WITH_ADDR)) {
             // Contract signature with address
             address contractOwner = address(bytes20(userOp.signature[1:21]));

--- a/src/MultiOwnerLightAccount.sol
+++ b/src/MultiOwnerLightAccount.sol
@@ -130,7 +130,6 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
     /// @dev Implement template method of BaseAccount.
     /// Uses a modified version of `SignatureChecker.isValidSignatureNow` in which the digest is wrapped with an
     /// "Ethereum Signed Message" envelope for the EOA-owner case but not in the ERC-1271 contract-owner case.
-    /// The SignatureType.CONTRACT case is excluded here to prevent potential gas griefing attacks.
     function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
         internal
         virtual
@@ -150,8 +149,7 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
             // Contract signature with address
             address contractOwner = address(bytes20(userOp.signature[1:21]));
             bytes memory signature = userOp.signature[21:];
-            return
-                _successToValidationData(_isValidContractOwnerSignatureNowSingle(contractOwner, userOpHash, signature));
+            return _successToValidationData(_isValidContractOwnerSignatureNow(contractOwner, userOpHash, signature));
         }
         revert InvalidSignatureType();
     }
@@ -172,36 +170,13 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
     /// @param digest The digest to be checked.
     /// @param signature The signature to be checked.
     /// @return True if the signature is valid and by an owner, false otherwise.
-    function _isValidContractOwnerSignatureNowSingle(address contractOwner, bytes32 digest, bytes memory signature)
+    function _isValidContractOwnerSignatureNow(address contractOwner, bytes32 digest, bytes memory signature)
         internal
         view
         returns (bool)
     {
         return SignatureChecker.isValidERC1271SignatureNow(contractOwner, digest, signature)
             && _getStorage().owners.contains(contractOwner.toSetValue());
-    }
-
-    /// @notice Check if the signature is a valid ERC-1271 signature by a contract owner for the given digest by
-    /// checking all owners in a loop.
-    /// @dev Susceptible to denial-of-service by a malicious owner contract. To avoid this, use a signature type that
-    /// includes the owner address.
-    /// @param digest The digest to be checked.
-    /// @param signature The signature to be checked.
-    /// @return True if the signature is valid and by an owner, false otherwise.
-    function _isValidContractOwnerSignatureNowLoop(bytes32 digest, bytes memory signature)
-        internal
-        view
-        returns (bool)
-    {
-        LightAccountStorage storage _storage = _getStorage();
-        address[] memory owners_ = _storage.owners.getAll().toAddressArray();
-        uint256 length = owners_.length;
-        for (uint256 i = 0; i < length; ++i) {
-            if (SignatureChecker.isValidERC1271SignatureNow(owners_[i], digest, signature)) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /// @dev The signature is valid if it is signed by the owner's private key (if the owner is an EOA) or if it is a
@@ -221,15 +196,11 @@ contract MultiOwnerLightAccount is BaseLightAccount, CustomSlotInitializable {
             // EOA signature
             bytes memory signature = trimmedSignature[1:];
             return _isValidEOAOwnerSignature(derivedHash, signature);
-        } else if (signatureType == uint8(SignatureType.CONTRACT)) {
-            // Contract signature without address
-            bytes memory signature = trimmedSignature[1:];
-            return _isValidContractOwnerSignatureNowLoop(derivedHash, signature);
         } else if (signatureType == uint8(SignatureType.CONTRACT_WITH_ADDR)) {
             // Contract signature with address
             address contractOwner = address(bytes20(trimmedSignature[1:21]));
             bytes memory signature = trimmedSignature[21:];
-            return _isValidContractOwnerSignatureNowSingle(contractOwner, derivedHash, signature);
+            return _isValidContractOwnerSignatureNow(contractOwner, derivedHash, signature);
         }
         revert InvalidSignatureType();
     }

--- a/test/MultiOwnerLightAccount.t.sol
+++ b/test/MultiOwnerLightAccount.t.sol
@@ -72,19 +72,6 @@ contract MultiOwnerLightAccountTest is Test {
         assertTrue(lightSwitch.on());
     }
 
-    function testExecuteCanBeCalledByEntryPointWithContractOwnerUnspecified() public {
-        _useContractOwner();
-        PackedUserOperation memory op = _getUnsignedOp(
-            abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
-        );
-        op.signature =
-            abi.encodePacked(BaseLightAccount.SignatureType.CONTRACT, contractOwner.sign(entryPoint.getUserOpHash(op)));
-        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
-        ops[0] = op;
-        entryPoint.handleOps(ops, BENEFICIARY);
-        assertTrue(lightSwitch.on());
-    }
-
     function testExecuteCanBeCalledByEntryPointWithContractOwnerSpecified() public {
         _useContractOwner();
         PackedUserOperation memory op = _getUnsignedOp(
@@ -109,6 +96,27 @@ contract MultiOwnerLightAccountTest is Test {
         PackedUserOperation[] memory ops = new PackedUserOperation[](1);
         ops[0] = op;
         vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA24 signature error"));
+        entryPoint.handleOps(ops, BENEFICIARY);
+    }
+
+    function testRejectsUserOpWithContractOwnerUnspecified() public {
+        _useContractOwner();
+        PackedUserOperation memory op = _getUnsignedOp(
+            abi.encodeCall(BaseLightAccount.execute, (address(lightSwitch), 0, abi.encodeCall(LightSwitch.turnOn, ())))
+        );
+        op.signature =
+            abi.encodePacked(BaseLightAccount.SignatureType.CONTRACT, contractOwner.sign(entryPoint.getUserOpHash(op)));
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = op;
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IEntryPoint.FailedOpWithRevert.selector,
+                0,
+                "AA23 reverted",
+                abi.encodePacked(BaseLightAccount.InvalidSignatureType.selector)
+            )
+        );
         entryPoint.handleOps(ops, BENEFICIARY);
     }
 
@@ -715,7 +723,7 @@ contract MultiOwnerLightAccountTest is Test {
                     bytes32(uint256(uint160(0x0000000071727De22E5E9d8BAf0edAc6f37da032)))
                 )
             ),
-            0x38d4efa1969cecb0d91391970b4a410bfc1f26e6a41a29bebfda173a9a739ea0
+            0x2fff6cdec81f22cf680a4c06509a0e189084f530d5fdbfa5325940de2d89cbff
         );
     }
 

--- a/test/MultiOwnerLightAccount.t.sol
+++ b/test/MultiOwnerLightAccount.t.sol
@@ -474,22 +474,6 @@ contract MultiOwnerLightAccountTest is Test {
         );
     }
 
-    function testIsValidSignatureForContractOwnerUnspecified() public {
-        _useContractOwner();
-        bytes32 child = keccak256(abi.encode(_CHILD_TYPEHASH, "hello world"));
-        bytes memory signature = abi.encodePacked(
-            BaseLightAccount.SignatureType.CONTRACT,
-            contractOwner.sign(_toERC1271Hash(child)),
-            _PARENT_TYPEHASH,
-            _domainSeparatorB(),
-            child
-        );
-        assertEq(
-            account.isValidSignature(_toChildHash(child), signature),
-            bytes4(keccak256("isValidSignature(bytes32,bytes)"))
-        );
-    }
-
     function testIsValidSignatureForContractOwnerSpecified() public {
         _useContractOwner();
         bytes32 child = keccak256(abi.encode(_CHILD_TYPEHASH, "hello world"));
@@ -505,6 +489,20 @@ contract MultiOwnerLightAccountTest is Test {
             account.isValidSignature(_toChildHash(child), signature),
             bytes4(keccak256("isValidSignature(bytes32,bytes)"))
         );
+    }
+
+    function testIsValidSignatureRejectsContractOwnerUnspecified() public {
+        _useContractOwner();
+        bytes32 child = keccak256(abi.encode(_CHILD_TYPEHASH, "hello world"));
+        bytes memory signature = abi.encodePacked(
+            BaseLightAccount.SignatureType.CONTRACT,
+            contractOwner.sign(_toERC1271Hash(child)),
+            _PARENT_TYPEHASH,
+            _domainSeparatorB(),
+            child
+        );
+        vm.expectRevert(abi.encodePacked(BaseLightAccount.InvalidSignatureType.selector));
+        account.isValidSignature(_toChildHash(child), signature);
     }
 
     function testIsValidSignatureRejectsInvalidEOA() public {
@@ -539,7 +537,8 @@ contract MultiOwnerLightAccountTest is Test {
         // Signature should fail, because the contract owner is not an owner
         bytes32 child = keccak256(abi.encode(_CHILD_TYPEHASH, "hello world"));
         bytes memory signature = abi.encodePacked(
-            BaseLightAccount.SignatureType.CONTRACT,
+            BaseLightAccount.SignatureType.CONTRACT_WITH_ADDR,
+            contractOwner,
             contractOwner.sign(_toERC1271Hash(child)),
             _PARENT_TYPEHASH,
             _domainSeparatorB(),
@@ -571,19 +570,6 @@ contract MultiOwnerLightAccountTest is Test {
         assertEq(account.isValidSignature(childHash, signature), bytes4(keccak256("isValidSignature(bytes32,bytes)")));
     }
 
-    function testIsValidSignaturePersonalSignForContractOwnerUnspecified() public {
-        _useContractOwner();
-        string memory message = "hello world";
-        bytes32 childHash =
-            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", bytes(message).length, message));
-        bytes memory signature = abi.encodePacked(
-            BaseLightAccount.SignatureType.CONTRACT,
-            contractOwner.sign(_toERC1271HashPersonalSign(childHash)),
-            _PARENT_TYPEHASH
-        );
-        assertEq(account.isValidSignature(childHash, signature), bytes4(keccak256("isValidSignature(bytes32,bytes)")));
-    }
-
     function testIsValidSignaturePersonalSignForContractOwnerSpecified() public {
         _useContractOwner();
         string memory message = "hello world";
@@ -596,6 +582,20 @@ contract MultiOwnerLightAccountTest is Test {
             _PARENT_TYPEHASH
         );
         assertEq(account.isValidSignature(childHash, signature), bytes4(keccak256("isValidSignature(bytes32,bytes)")));
+    }
+
+    function testIsValidSignaturePersonalSignRejectsContractOwnerUnspecified() public {
+        _useContractOwner();
+        string memory message = "hello world";
+        bytes32 childHash =
+            keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", bytes(message).length, message));
+        bytes memory signature = abi.encodePacked(
+            BaseLightAccount.SignatureType.CONTRACT,
+            contractOwner.sign(_toERC1271HashPersonalSign(childHash)),
+            _PARENT_TYPEHASH
+        );
+        vm.expectRevert(abi.encodePacked(BaseLightAccount.InvalidSignatureType.selector));
+        account.isValidSignature(childHash, signature);
     }
 
     function testIsValidSignaturePersonalSignRejectsInvalid() public {
@@ -723,7 +723,7 @@ contract MultiOwnerLightAccountTest is Test {
                     bytes32(uint256(uint160(0x0000000071727De22E5E9d8BAf0edAc6f37da032)))
                 )
             ),
-            0x2fff6cdec81f22cf680a4c06509a0e189084f530d5fdbfa5325940de2d89cbff
+            0xd5c53db2178734fbfa4566d827f4af4dbb897979875488640713b7b7d4689d1a
         );
     }
 


### PR DESCRIPTION
Removed this case for user op validation and adjusted tests.