### PR TITLE
fix: [ALC-LA2-1] document internal function _getCombinedSalt to expect clean upper bits for owner

### DIFF
--- a/src/LightAccountFactory.sol
+++ b/src/LightAccountFactory.sol
@@ -50,6 +50,7 @@ contract LightAccountFactory is BaseLightAccountFactory {
     }
 
     /// @notice Compute the hash of the owner and salt in scratch space memory.
+    /// @dev The caller is responsible for cleaning the upper bits of the owner address parameter.
     /// @param owner The owner of the account to be created.
     /// @param salt A salt, which can be changed to create multiple accounts with the same owner.
     /// @return combinedSalt The hash of the owner and salt.

--- a/test/LightAccount.t.sol
+++ b/test/LightAccount.t.sol
@@ -556,7 +556,7 @@ contract LightAccountTest is Test {
                     bytes32(uint256(uint160(0x0000000071727De22E5E9d8BAf0edAc6f37da032)))
                 )
             ),
-            0xefe804f2c00bf5ade462dc2ba6c9c59fe5a69a24914737fbd7613bdb2dfcf600
+            0xd163ff9f4127df29ad58e4686d0f5367607e32fe777a91a8f4d86fdab6e23640
         );
     }
 


### PR DESCRIPTION
Because the owner parameter is passed in from an external call parameter, the upper bits should already be clean. But helpful to document this for `_getCombinedSalt`.