### PR TITLE
fix: remove improper natspec on deploy scripts

### DIFF
--- a/script/Deploy_LightAccountFactory.s.sol
+++ b/script/Deploy_LightAccountFactory.s.sol
@@ -7,8 +7,6 @@ import {IEntryPoint} from "account-abstraction/interfaces/IEntryPoint.sol";
 
 import {LightAccountFactory} from "../src/LightAccountFactory.sol";
 
-// @notice Deploys LightAccountFactory
-// @dev To run: `forge script script/Deploy_LightAccountFactory.s.sol:Deploy_LightAccountFactory --broadcast --rpc-url ${RPC_URL} --verify -vvvv`
 contract Deploy_LightAccountFactory is Script {
     // Load entrypoint from env
     address public entryPointAddr = vm.envAddress("ENTRYPOINT");

--- a/script/Deploy_MultiOwnerLightAccountFactory.s.sol
+++ b/script/Deploy_MultiOwnerLightAccountFactory.s.sol
@@ -7,8 +7,6 @@ import {IEntryPoint} from "account-abstraction/interfaces/IEntryPoint.sol";
 
 import {MultiOwnerLightAccountFactory} from "../src/MultiOwnerLightAccountFactory.sol";
 
-// @notice Deploys MultiOwnerLightAccountFactory
-// @dev To run: `forge script script/Deploy_MultiOwnerLightAccountFactory.s.sol:Deploy_MultiOwnerLightAccountFactory --broadcast --rpc-url ${RPC_URL} --verify -vvvv`
 contract Deploy_MultiOwnerLightAccountFactory is Script {
     // Load entrypoint from env
     address public entryPointAddr = vm.envAddress("ENTRYPOINT");


### PR DESCRIPTION
These weren't proper NatSpec anyway and not helpful since we have the command in the README.