### PR TITLE
fix(script): clamp stake delta instead of underflowing

### DIFF
--- a/script/Deploy_LightAccountFactory.s.sol
+++ b/script/Deploy_LightAccountFactory.s.sol
@@ -57,7 +57,9 @@ contract Deploy_LightAccountFactory is Script {
         uint32 unstakeDelaySec = uint32(vm.envOr("UNSTAKE_DELAY_SEC", uint32(86400)));
         uint256 requiredStakeAmount = vm.envUint("REQUIRED_STAKE_AMOUNT");
         uint256 currentStakedAmount = entryPoint.getDepositInfo(factoryAddr).stake;
-        uint256 stakeAmount = requiredStakeAmount - currentStakedAmount;
+        // Clamp rather than subtract directly: a factory staked above the required amount underflows, and
+        // the deployer passes a required amount of 0 when staking is meant to be skipped entirely.
+        uint256 stakeAmount = requiredStakeAmount > currentStakedAmount ? requiredStakeAmount - currentStakedAmount : 0;
 
         if (stakeAmount > 0) {
             LightAccountFactory(payable(factoryAddr)).addStake{value: stakeAmount}(unstakeDelaySec, stakeAmount);


### PR DESCRIPTION
## Problem

`_addStakeForFactory` subtracts before it checks:

```solidity
uint256 stakeAmount = requiredStakeAmount - currentStakedAmount;

if (stakeAmount > 0) {
```

The `stakeAmount > 0` guard sits one line too late, so it never protects the subtraction. Any factory already staked at or above the required amount panics with `arithmetic underflow or overflow (0x11)` and the whole script aborts.

## How it surfaced

The wallet-services deployer passes `REQUIRED_STAKE_AMOUNT=0` for this factory, because its config entry sets `skipStaking: true`. Against an unstaked factory that is `0 - 0` and passes silently; once the factory holds stake it becomes `0 - 1e17` and reverts.

That took down a production `ETH_SEPOLIA` contract deployment — the factory at `0x000000000000B1c70Df4DC2CcF86372714e14154` is staked with `1e17`, so every attempt failed and the run exhausted its retries:

```
Factory already deployed at: 0x000000000000B1c70Df4DC2CcF86372714e14154
getDepositInfo(...) → DepositInfo({ deposit: 0, staked: true, stake: 100000000000000000, ... })
← [Revert] panic: arithmetic underflow or overflow (0x11)
```

The deployer runs contracts sequentially and stops at the first failure, so every entry after this one was blocked on every chain.

Not a recent regression: the subtraction dates to `0a60a11` (2024-04-29). It only became reachable once the deployer started passing `0`, and it fires per-chain as each factory gets staked.

## Fix

```solidity
uint256 stakeAmount = requiredStakeAmount > currentStakedAmount ? requiredStakeAmount - currentStakedAmount : 0;
```

Clamping preserves the existing `else { console.log("Factory already staked") }` branch, which is what the guard was written to express — an already-staked factory should be a no-op, not a revert.

## Note

`v2.2.x` carries the identical bug at the same lines (`9368be5`), and it is the very next entry in the deployer config — fixing only this branch moves the failure rather than clearing it. Companion PR opened against `v2.2.x`.

## Test plan

- `forge build` — compiles clean
- `forge fmt --check` — clean
- Behavior unchanged when `required > current` (stakes the delta) and when `required == current` (already-staked branch); the previously-panicking `required < current` case now also takes the already-staked branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)