### PR TITLE
fix(script): clamp stake delta instead of underflowing

### DIFF
--- a/script/Deploy_LightAccountFactory.s.sol
+++ b/script/Deploy_LightAccountFactory.s.sol
@@ -57,7 +57,9 @@ contract Deploy_LightAccountFactory is Script {
         uint32 unstakeDelaySec = uint32(vm.envOr("UNSTAKE_DELAY_SEC", uint32(86400)));
         uint256 requiredStakeAmount = vm.envUint("REQUIRED_STAKE_AMOUNT");
         uint256 currentStakedAmount = entryPoint.getDepositInfo(factoryAddr).stake;
-        uint256 stakeAmount = requiredStakeAmount - currentStakedAmount;
+        // Clamp rather than subtract directly: a factory staked above the required amount underflows, and
+        // the deployer passes a required amount of 0 when staking is meant to be skipped entirely.
+        uint256 stakeAmount = requiredStakeAmount > currentStakedAmount ? requiredStakeAmount - currentStakedAmount : 0;
 
         if (stakeAmount > 0) {
             LightAccountFactory(payable(factoryAddr)).addStake{value: stakeAmount}(unstakeDelaySec, stakeAmount);


### PR DESCRIPTION
Companion to #77, which applies the same fix to `v2.1.x`.

## Problem

`_addStakeForFactory` subtracts before it checks:

```solidity
uint256 stakeAmount = requiredStakeAmount - currentStakedAmount;

if (stakeAmount > 0) {
```

The `stakeAmount > 0` guard sits one line too late, so it never protects the subtraction. Any factory already staked at or above the required amount panics with `arithmetic underflow or overflow (0x11)` and the whole script aborts.

## Why this branch needs it too

The wallet-services deployer passes `REQUIRED_STAKE_AMOUNT=0` here, because the config entry for this factory sets `skipStaking: true`. Against an unstaked factory that is `0 - 0` and passes silently; once the factory holds stake it becomes `0 - stake` and reverts.

This branch is the deployer entry immediately after the `v2.1.x` one, and they run sequentially — so fixing only #77 moves the failure from one entry to the next rather than clearing it. Both are needed to unblock production contract deployments.

## Fix

```solidity
uint256 stakeAmount = requiredStakeAmount > currentStakedAmount ? requiredStakeAmount - currentStakedAmount : 0;
```

Clamping preserves the existing `else { console.log("Factory already staked") }` branch, which is what the guard was written to express — an already-staked factory should be a no-op, not a revert.

## Test plan

- `forge build` — compiles clean
- `forge fmt --check` — clean
- Behavior unchanged when `required > current` (stakes the delta) and when `required == current` (already-staked branch); the previously-panicking `required < current` case now also takes the already-staked branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
